### PR TITLE
ci: add vitest config + fix CI order (pnpm before setup-node)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    coverage: { provider: 'v8', reporter: ['text-summary','lcov','json-summary'] }
+  },
+});


### PR DESCRIPTION
- Adds vitest.config.ts (non-functional change; enables coverage/reporters)
- Updates CI step order so pnpm is enabled via corepack before setup-node cache
- No application logic changed
