### PR TITLE
FM-64: overlay gating (zone/flood/BAL) + assessAll combiner + tests

### DIFF
--- a/src/engine/assessAll.ts
+++ b/src/engine/assessAll.ts
@@ -1,0 +1,36 @@
+import type { RuleInput, RuleResult } from './types';
+import { assess } from './assess';
+import type { OverlaySnapshot, OverlayFinding } from '../overlay/types';
+import { evaluateOverlays } from '../overlay/overlayRules';
+
+export type OverallVerdict = 'LIKELY_EXEMPT' | 'NOT_EXEMPT';
+
+export interface CombinedResult {
+  verdict: OverallVerdict;
+  reasons: string[];
+  details: {
+    structure: RuleResult;
+    overlays: OverlayFinding;
+  };
+}
+
+/**
+ * Combine structure checks (Sprint 2) with overlay gates (Sprint 3).
+ */
+export function assessAll(input: RuleInput, overlay: OverlaySnapshot): CombinedResult {
+  const structure = assess(input);
+  const overlayFinding = evaluateOverlays(overlay);
+
+  const ok = structure.verdict === 'LIKELY_EXEMPT' && overlayFinding.ok;
+
+  const reasons = [
+    ...structure.reasons,
+    ...(overlayFinding.ok ? [] : overlayFinding.reasons),
+  ];
+
+  return {
+    verdict: ok ? 'LIKELY_EXEMPT' : 'NOT_EXEMPT',
+    reasons,
+    details: { structure, overlays: overlayFinding },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './engine/types';
 export * from './engine/assess';
+export * from './engine/assessAll';
+export * from './overlay/types';
+export * from './overlay/overlayRules';

--- a/src/overlay/overlayRules.ts
+++ b/src/overlay/overlayRules.ts
@@ -1,0 +1,19 @@
+import type { OverlaySnapshot, OverlayFinding } from './types';
+
+const RESIDENTIAL = new Set(['R1','R2','R3','R4','R5']);
+
+export function evaluateOverlays(snapshot: OverlaySnapshot): OverlayFinding {
+  const reasons: string[] = [];
+
+  if (!RESIDENTIAL.has(snapshot.zone)) {
+    reasons.push(`Zone ${snapshot.zone} is not residential (R1–R5).`);
+  }
+  if (snapshot.floodControlLot) {
+    reasons.push('Lot intersects a flood control area.');
+  }
+  if (snapshot.bal === 'BAL-40' || snapshot.bal === 'BAL-FZ') {
+    reasons.push(`Bushfire category ${snapshot.bal} (extreme).`);
+  }
+
+  return { ok: reasons.length === 0, reasons, snapshot };
+}

--- a/src/overlay/types.ts
+++ b/src/overlay/types.ts
@@ -1,0 +1,23 @@
+export type Zone =
+  | 'R1'|'R2'|'R3'|'R4'|'R5'
+  | 'RU1'|'RU2'|'RU3'|'RU4'|'RU5'|'RU6'
+  | 'IN1'|'IN2'|'IN3'|'IN4'
+  | 'B5'|'B6'|'B7'|'B8'
+  | 'SP1'|'SP2'|'SP3'
+  | 'RE1'|'RE2'|'C1'|'C2'|'C3'|'C4'
+  | 'W1'|'W2'|'W3'
+  | 'UNKNOWN';
+
+export type BAL = 'BAL-LOW'|'BAL-12.5'|'BAL-19'|'BAL-29'|'BAL-40'|'BAL-FZ'|'UNKNOWN';
+
+export interface OverlaySnapshot {
+  zone: Zone;
+  floodControlLot: boolean;
+  bal: BAL;
+}
+
+export interface OverlayFinding {
+  ok: boolean;
+  reasons: string[];
+  snapshot: OverlaySnapshot;
+}

--- a/tests/assessAll.test.ts
+++ b/tests/assessAll.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { assessAll } from '../src/engine/assessAll';
+import type { RuleInput } from '../src/engine/types';
+import type { OverlaySnapshot } from '../src/overlay/types';
+
+const goodStructure: RuleInput = {
+  type: 'shed', length: 4, width: 5, height: 2.4, setback: 1.0
+};
+
+const goodOverlay: OverlaySnapshot = {
+  zone: 'R2', floodControlLot: false, bal: 'BAL-12.5'
+};
+
+describe('assessAll', () => {
+  it('LIKELY_EXEMPT when structure + overlays pass', () => {
+    const res = assessAll(goodStructure, goodOverlay);
+    expect(res.verdict).toBe('LIKELY_EXEMPT');
+    expect(res.details.overlays.ok).toBe(true);
+  });
+
+  it('NOT_EXEMPT when overlays fail even if structure passes', () => {
+    const badOverlay: OverlaySnapshot = { ...goodOverlay, zone: 'IN1' };
+    const res = assessAll(goodStructure, badOverlay);
+    expect(res.verdict).toBe('NOT_EXEMPT');
+    expect(res.reasons.join(' ')).toMatch(/not residential/i);
+  });
+});

--- a/tests/overlayRules.test.ts
+++ b/tests/overlayRules.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateOverlays } from '../src/overlay/overlayRules';
+import type { OverlaySnapshot } from '../src/overlay/types';
+
+const base: OverlaySnapshot = { zone: 'R2', floodControlLot: false, bal: 'BAL-12.5' };
+
+describe('Overlay rules', () => {
+  it('passes for residential, not flood, low BAL', () => {
+    const res = evaluateOverlays(base);
+    expect(res.ok).toBe(true);
+    expect(res.reasons).toEqual([]);
+  });
+
+  it('fails for non-residential zone', () => {
+    const snap: OverlaySnapshot = { ...base, zone: 'IN1' };
+    const res = evaluateOverlays(snap);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.join(' ')).toMatch(/not residential/i);
+  });
+
+  it('fails for flood control lot', () => {
+    const snap: OverlaySnapshot = { ...base, floodControlLot: true };
+    const res = evaluateOverlays(snap);
+    expect(res.ok).toBe(false);
+    expect(res.reasons.join(' ')).toMatch(/flood control/i);
+  });
+
+  it('fails for BAL-40 and BAL-FZ', () => {
+    for (const bal of ['BAL-40','BAL-FZ'] as const) {
+      const snap: OverlaySnapshot = { ...base, bal };
+      const res = evaluateOverlays(snap);
+      expect(res.ok).toBe(false);
+      expect(res.reasons.join(' ')).toMatch(/bushfire.*extreme/i);
+    }
+  });
+});


### PR DESCRIPTION
Jira: FM-64 — Overlay gating for zoning/bushfire/flood

Summary

Adds a lightweight overlay gate and a combiner so our Sprint-2 structure checks can be evaluated together with zoning/bushfire/flood overlays. Backend-only; will be fed by map/GIS data in a later PR.

What’s in this PR

Types: Zone, BAL, OverlaySnapshot, OverlayFinding

Overlay rules: evaluateOverlays(snapshot)

Blocks non-residential zones (R1–R5 only allowed)

Blocks lots flagged as flood control

Blocks BAL-40 and BAL-FZ

Combiner: assessAll(ruleInput, snapshot)

Runs Sprint-2 structure checks (area ≤ 20 m², height ≤ 3.0 m, boundary ≥ 0.5 m)

ANDs them with the overlay gates

Returns merged verdict + surfaced reasons

Public exports wired in src/index.ts

Unit tests: overlayRules.test.ts, assessAll.test.ts (11 total passing)

Files changed

src/overlay/types.ts — overlay types

src/overlay/overlayRules.ts — evaluateOverlays

src/engine/assessAll.ts — structure + overlay combiner

src/index.ts — exports

tests/overlayRules.test.ts, tests/assessAll.test.ts

How to test
pnpm i
pnpm typecheck
pnpm test    # expect all 11 tests to pass

Example usage
import { assessAll, type OverlaySnapshot, type RuleInput } from './src';

const structure: RuleInput = {
  type: 'shed',
  length: 4,
  width: 5,
  height: 2.4,
  setback: 1.0,
};

const overlay: OverlaySnapshot = {
  zone: 'R2',
  floodControlLot: false,
  bal: 'BAL-12.5',
};

const result = assessAll(structure, overlay);
// => { verdict: 'LIKELY_EXEMPT', reasons: [...], details: { structure, overlays } }

Out of scope / follow-ups

No map service wiring yet — callers must supply OverlaySnapshot.

Future overlays (heritage, watercourses, easements, etc.) can extend evaluateOverlays.

Risks / Notes

No breaking changes to existing structure rules.

Pure functions; no I/O, DB, or API changes.

Checklist

 Unit tests added & passing locally - done

 Type-safe public exports - done 

 Clear failure reasons when overlays block exemption - done 

 Reviewer assigned & CI green - (neha)